### PR TITLE
GSLUX-781: Legends

### DIFF
--- a/config.json
+++ b/config.json
@@ -4,5 +4,6 @@
   "luxI18nUrl": "https://map.geoportail.lu/static/0",
   "luxOwsUrl": "https://wmsproxy.geoportail.lu/ogcproxywms",
   "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
-  "lux3dUrl": "https://acts3.geoportail.lu/3d-data/3d-tiles"
+  "lux3dUrl": "https://acts3.geoportail.lu/3d-data/3d-tiles",
+  "luxLegendUrl": "https://map.geoportail.lu/legends/get_html"
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -57,6 +57,7 @@ export default function lux3dviewerThemesyncPlugin(
 
     themes?.forEach((themeItem: ThemeItem) => {
       mapThemeToConfig(
+        vcsUiApp,
         pluginConfig,
         moduleConfig,
         themeItem,

--- a/src/model.ts
+++ b/src/model.ts
@@ -9,6 +9,7 @@ export type PluginConfig = {
   luxOwsUrl: string;
   luxWmtsUrl: string;
   lux3dUrl: string;
+  luxLegendUrl: string;
 };
 
 export interface ThemeItem {
@@ -20,6 +21,7 @@ export interface ThemeItem {
   imageType?: string;
   properties?: Record<string, unknown>;
   children?: ThemeItem[];
+  metadata?: Record<string, unknown>;
 }
 
 export interface Theme {


### PR DESCRIPTION
This PR generate the legend url during the layer tree creation.

⚠️ VCmap-ui is not configured to update the layer legend on local language change => VCmap-ui needs an update.
⚠️ Legends component needs an improvement to hide legend when api returns blank pages.
⚠️ Legends component needs an improvement to adapt its content according to the legend html returned by api, currently, the legend is displayed as an iframe with fixed width and height.

If the current display of the legends is not really satifying, the legend button can be deactivated in the 3dviewer config.
 
<img width="1053" height="685" alt="image" src="https://github.com/user-attachments/assets/2cdf13f3-18fc-468e-a2ae-f907d9f04694" />
