### PR TITLE
GSLUX-787: Cesium3d style to hide objects with given IDs

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,4 +1,4 @@
-Copyright (C) 2025 author <email>
+Copyright (C) 2025 author c2c
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by
@@ -7,8 +7,8 @@ the Free Software Foundation, either version 3 of the License, or
 
 This program is distributed in the hope that it will be useful,
 but WITHOUT ANY WARRANTY; without even the implied warranty of
-MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
 GNU General Public License for more details.
 
 You should have received a copy of the GNU General Public License
-along with this program.  If not, see <http://www.gnu.org/licenses/>.
+along with this program. If not, see <http://www.gnu.org/licenses/>.

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoportallux/lux-3dviewer-themesync",
-  "luxThemesUrl": "https://map.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&cache_version=0&background=background",
+  "luxThemesUrl": "https://migration.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&cache_version=0&background=background",
   "luxI18nUrl": "https://map.geoportail.lu/static/0",
   "luxOwsUrl": "https://wmsproxy.geoportail.lu/ogcproxywms",
   "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",

--- a/src/model.ts
+++ b/src/model.ts
@@ -16,12 +16,20 @@ export interface ThemeItem {
   id: number;
   name: string;
   source?: string;
-  style?: string;
+  style?: string | LayerStyle;
   type?: 'WMS' | 'WMTS' | '3D';
   imageType?: string;
   properties?: Record<string, unknown>;
   children?: ThemeItem[];
-  metadata?: Record<string, unknown>;
+  metadata?: {
+    // eslint-disable-next-line  @typescript-eslint/naming-convention
+    legend_name?: string;
+    // eslint-disable-next-line  @typescript-eslint/naming-convention
+    ol3d_options?: Record<string, unknown> & {
+      cesium3DTileStyle?: Record<string, unknown>;
+      vcsHiddenObjectIds?: string[];
+    };
+  } & Record<string, unknown>;
 }
 
 export interface Theme {
@@ -43,11 +51,16 @@ export interface ThemesResponse {
   };
 }
 
+export interface LayerStyle {
+  type: string;
+  declarativeStyle: Record<string, unknown>;
+}
+
 export interface LayerConfig {
   id?: number;
   name: string;
   source?: string;
-  style?: string;
+  style?: string | LayerStyle;
   layers?: string;
   activeOnStartup: boolean;
   allowPicking?: boolean;


### PR DESCRIPTION
This PR introduces the capability to hide objects according to their IDs.
To hide objects, either add a Cesium3dTileStyle directly in the geoportal's backoffice, or add an array of IDs, eg:

in the metadata `ol3d_options`:
```
{
"cesium3DTileStyle": {
 "show": "! ( ${id} === '000_the_ID'||${id} === '001_the_ID' )"
} 
}
```
or
```
{
"vcsHiddenObjects": ["000_the_ID", "001_the_ID"]
}
```

You can test with: http://localhost:8008/?state=[[[6.246301929397832%2C49.602445187063246%2C902.6218469591353]%2C[6.2446633276210965%2C49.609730093432496%2C346.50769424708506]%2C989.9027432002412%2C351.68422260908625%2C-34.18310147272193%2C359.99953378935504]%2C%22cesium%22%2C[%22LuxConfig%22%2C%22bce01956-6057-432d-a4a1-b7e20b42fbb2%22%2C%22592447fd-6bf1-4a3d-89d5-ed38acf2099c%22%2C%227a5a5157-90f9-494b-a98a-6b71ba19e7a0%22%2C%227adf63cd-ea33-4b25-ae36-80ed89cd9c1d%22%2C%22a1333feb-46e7-409d-a67d-a91ecd788747%22%2C%22catalogConfig%22]%2C[]%2C[[%22%40geoportallux%2Flux-3dviewer-themesync%22%2C{%22prop%22%3A%22*%22}]%2C[%22%40geoportallux%2Flux-3dviewer-plugin-back-to-2d-portal%22%2C{%22prop%22%3A%22*%22}]]%2C0%2C[]], the prison building shouldn't be displayed.