### PR TITLE
feat: info balloon on 3d objects

### DIFF
--- a/lux.config.json
+++ b/lux.config.json
@@ -512,6 +512,11 @@
   ],
   "featureInfo": [
     {
+      "type": "BalloonFeatureInfoView",
+      "name": "balloon3d",
+      "attributeKeys": ["BUILDINGID"]
+    },
+    {
       "type": "TableFeatureInfoView",
       "name": "tableAllWithTemplateHeader",
       "keyMapping": {

--- a/src/model.ts
+++ b/src/model.ts
@@ -33,6 +33,7 @@ export interface ThemeItem {
       vcsHiddenObjectIds?: string[];
       vcsClippingPolygons?: Array<Array<[number, number]>>;
     };
+    is_queryable?: boolean;
   } & Record<string, unknown>;
 }
 
@@ -72,7 +73,7 @@ export interface LayerConfig {
   layers?: string;
   activeOnStartup: boolean;
   allowPicking?: boolean;
-  properties?: Record<string, unknown>;
+  properties: Record<string, unknown>;
   type: string;
   url?: string;
   tilingSchema?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -87,7 +87,7 @@ export function mapThemeToConfig(
       style: themeItem.style,
       layers: themeItem.name,
       activeOnStartup: false,
-      allowPicking: false,
+      allowPicking: !!themeItem.metadata?.is_queryable,
       properties: {
         title: `layers.${themeItem.name}.title`, // use translations for layers (content tree and elsewhere). does not contain nodes
         legend: [
@@ -139,8 +139,10 @@ export function mapThemeToConfig(
           ...layerConfig,
           url: `${themeItem.url}/${themeItem.layer}/tileset.json`,
           type: 'CesiumTilesetLayer',
-          style: get3dStyle(themeItem),
+          style: get3dStyle(themeItem)
         };
+        layerConfig.allowPicking = true;
+        layerConfig.properties.featureInfo = "balloon3d";
         break;
       case 'mesh':
         layerConfig = {


### PR DESCRIPTION
This PR activates the info balloons for 3d objects (displays `OBJECTID` in info balloon, if available in the returned `tileset.json)` 

<img width="1089" height="964" alt="image" src="https://github.com/user-attachments/assets/0dd444bc-ebb1-4ea7-9a21-ab10b75793f3" />
