### PR TITLE
fix: improve raster quality when zooming

### DIFF
--- a/src/model.ts
+++ b/src/model.ts
@@ -101,6 +101,8 @@ export interface LayerConfig {
   requestVertexNormals?: boolean;
   offset?: number[];
   zIndex?: number;
+  minLevel?: number,
+  maxLevel?: number // for Cesium zoom quality on raster
 }
 
 export interface ContentTreeItemConfig {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -132,6 +132,8 @@ export function mapThemeToConfig(
             format: 'image/png',
             transparent: true,
           },
+          minLevel: 0,
+          maxLevel: 22
         };
         break;
       case 'WMTS':
@@ -147,6 +149,8 @@ export function mapThemeToConfig(
               epsg: 'EPSG:4326',
             },
           },
+          minLevel: 0,
+          maxLevel: 22
         };
         break;
       case 'data':


### PR DESCRIPTION
This PR improves the WMS and WMTS quality display when zooming.

You can check: http://localhost:8008/?state=[[[6.128041259104086,49.60861868742982,395.268394169776],[6.128049877298624,49.609290789508904,288.4177776852251],130.40680693271034,0.4774120243036274,-55.02148228737548,359.61245547675503],%22cesium%22,[%22LuxConfig%22,%22d5ce715a-5200-4eef-b6e9-dd1431417e9f%22,%226c04429d-37cb-41e6-acd0-14e5b69ac06e%22,%2290db840d-19b8-42e8-b0e6-2bdd9c0198e2%22,%22ea0ea74c-aa9f-40ef-850b-695cff5af203%22,%220bfe3d22-3950-4d25-ae86-444c3690a649%22,%22catalogConfig%22],[],[[%22@geoportallux/lux-3dviewer-themesync%22,{%22prop%22:%22*%22}],[%22@geoportallux/lux-3dviewer-plugin-back-to-2d-portal%22,{%22prop%22:%22*%22}]],0,[]]

compared to https://map.geoportail.lu/theme/main?version=3&X=682156&Y=6378898&zoom=19&rotation=0&features=&lang=fr&layers=&opacities=&time=&bgLayer=orthogr_2013_global&3d_layers=&3d_enabled=true&3d_lon=6.12804&3d_lat=49.60929&3d_elevation=343&3d_heading=3.540&3d_pitch=-70.331

(should be same quality now)

<img width="1920" height="987" alt="image" src="https://github.com/user-attachments/assets/c74ea047-7ffb-4d84-b8b4-59b5e2b9b24e" />

<img width="1868" height="958" alt="image" src="https://github.com/user-attachments/assets/0f0f1286-631b-4b8d-9a76-e7a1b53d944c" />


Whereas before:

<img width="1920" height="987" alt="image" src="https://github.com/user-attachments/assets/44cb92bc-a50b-4412-aba3-db81ded2723e" />



