### PR TITLE
Add metadata info link to catalog when metadata uuid is available

### DIFF
--- a/config.json
+++ b/config.json
@@ -5,5 +5,6 @@
   "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
   "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
   "luxLegendUrl": "https://map.geoportail.lu/legends/get_html",
-  "luxDefaultBaselayer": "orthogr_2013_global"
+  "luxDefaultBaselayer": "orthogr_2013_global",
+  "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv"
 }

--- a/src/model.ts
+++ b/src/model.ts
@@ -10,6 +10,7 @@ export type PluginConfig = {
   luxWmtsUrl: string;
   luxLegendUrl: string;
   luxDefaultBaselayer: string;
+  luxGeonetworkUrl?: string;
 };
 
 export interface ThemeItem {
@@ -40,6 +41,8 @@ export interface ThemeItem {
     };
     // eslint-disable-next-line  @typescript-eslint/naming-convention
     is_queryable?: boolean;
+    // eslint-disable-next-line  @typescript-eslint/naming-convention
+    metadata_id?: string;
   } & Record<string, unknown>;
 }
 
@@ -83,7 +86,7 @@ export interface LayerConfig {
   activeOnStartup: boolean;
   allowPicking?: boolean;
   properties: Record<string, unknown>;
-  type: string;
+  type?: string;
   url?: string;
   format?: string;
   tilingSchema?: string;
@@ -102,8 +105,8 @@ export interface LayerConfig {
   requestVertexNormals?: boolean;
   offset?: number[];
   zIndex?: number;
-  minLevel?: number,
-  maxLevel?: number // for Cesium zoom quality on raster
+  minLevel?: number;
+  maxLevel?: number; // for Cesium zoom quality on raster
 }
 
 export interface ContentTreeItemConfig {
@@ -114,6 +117,7 @@ export interface ContentTreeItemConfig {
   visible?: boolean;
   icon?: string;
   tooltip?: string;
+  infoUrl?: string;
 }
 
 export interface ClippingPolygon {


### PR DESCRIPTION
This PR adds an info icon in the layer tree when layer's metadata id is available, generating a link to the gn catalog.

<img width="332" height="427" alt="image" src="https://github.com/user-attachments/assets/fd0a99f4-deb0-4e7f-a71d-8b8d3eb576c6" />

NB. translation for tooltip in: https://github.com/Geoportail-Luxembourg/3dviewer/pull/11
