### PR TITLE
Activate baselayer received from URL

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { type VcsApp, VcsModule } from '@vcmap/core';
+import { VcsModule } from '@vcmap/core';
 import type { VcsPlugin, VcsUiApp, PluginConfigEditor } from '@vcmap/ui';
 import { name, version, mapVersion } from '../package.json';
 import {
@@ -10,7 +10,7 @@ import {
   type ThemesResponse,
   type Ol2dLayerType,
 } from './model';
-import { mapThemeToConfig } from './utils';
+import { setActiveBaselayer, mapThemeToConfig } from './utils';
 
 type PluginState = Record<never, never>;
 
@@ -25,7 +25,7 @@ export default function lux3dviewerThemesyncPlugin(
    * @param translations The translations to use.
    **/
   async function addThemes(
-    vcsUiApp: VcsApp,
+    vcsUiApp: VcsUiApp,
     themes: Theme[],
     terrainUrl: string,
     translations: Record<string, Record<string, string>>,
@@ -159,6 +159,7 @@ export default function lux3dviewerThemesyncPlugin(
       if (themesFiltered.length > 0) {
         await addThemes(vcsUiApp, themesFiltered, terrainUrl, flatTranslations);
       }
+      await setActiveBaselayer(vcsUiApp, pluginConfig, baselayers);
     },
     onVcsAppMounted(): void {},
     /**

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,4 +1,4 @@
-import type { VcsApp } from '@vcmap/core';
+import type { VcsUiApp } from '@vcmap/ui';
 import {
   type ContentTreeItemConfig,
   type LayerConfig,
@@ -75,7 +75,7 @@ function get3dStyle(themeItem: ThemeItem): LayerStyle | undefined {
 }
 
 export function mapThemeToConfig(
-  vcsUiApp: VcsApp,
+  vcsUiApp: VcsUiApp,
   pluginConfig: PluginConfig,
   moduleConfig: ModuleConfig,
   themeItem: ThemeItem,
@@ -118,9 +118,6 @@ export function mapThemeToConfig(
         ],
         ...themeItem.properties,
       },
-      ...(themeItem.layer === pluginConfig.luxDefaultBaselayer && {
-        activeOnStartup: true,
-      }),
     };
 
     if (themeItem.metadata?.exclusion) {
@@ -262,5 +259,23 @@ export function mapThemeToConfig(
         subParentName,
       );
     });
+  }
+}
+
+export async function setActiveBaselayer(
+  vcsUiApp: VcsUiApp,
+  pluginConfig: PluginConfig,
+  baselayers: ThemeItem[],
+): Promise<void> {
+  const state = await vcsUiApp.getState(true);
+  const stateHasBaselayer = baselayers.some((baseLayer) =>
+    state.layers?.some(
+      (stateLayer: { name: string }) => stateLayer.name === baseLayer.name,
+    ),
+  );
+  if (!stateHasBaselayer) {
+    await vcsUiApp.layers
+      .getByKey(pluginConfig.luxDefaultBaselayer)
+      ?.activate();
   }
 }


### PR DESCRIPTION
This PR only activates the `luxDefaultBaselayer` from the config if no `baselayer` is set in URL.