### PR TITLE
GSLUX-809: Integrate authentication into theme & layer fetching

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ These params (mostly URLs) must be indicated in the plugin config when deployed:
 - `luxWmtsUrl`- URL to WMTS
 - `luxLegendUrl` - URL to legends
 - `luxDefaultBaselayer` - name of the default baselayer to display
+- `credentials` - RequestCredentials property for theme fetching: `omit`, `same-origin` (default) or `include` (for dev only)
 
 ## Deploy plugin within map-ui
 
@@ -41,7 +42,8 @@ These params (mostly URLs) must be indicated in the plugin config when deployed:
       "luxOwsUrl": "...",
       "luxWmtsUrl": "...",
       "luxLegendUrl": "...",
-      "luxDefaultBaselayer": "..."
+      "luxDefaultBaselayer": "...",
+      "credentials": "...",
     },
 ```
 

--- a/config.json
+++ b/config.json
@@ -6,5 +6,6 @@
   "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
   "luxLegendUrl": "https://map.geoportail.lu/legends/get_html",
   "luxDefaultBaselayer": "orthogr_2013_global",
-  "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv"
+  "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv",
+  "credentials": "same-origin"
 }

--- a/config.json
+++ b/config.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoportallux/lux-3dviewer-themesync",
-  "luxThemesUrl": "https://migration.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&cache_version=0&background=background",
+  "luxThemesUrl": "https://migration.geoportail.lu/themes?limit=30&partitionlimit=5&interface=main&background=background",
   "luxI18nUrl": "https://map.geoportail.lu/static/0",
   "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
   "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",

--- a/src/index.ts
+++ b/src/index.ts
@@ -106,10 +106,11 @@ export default function lux3dviewerThemesyncPlugin(
   }
 
   async function loadThemes(vcsUiApp: VcsUiApp): Promise<void> {
-    const themesResponse: ThemesResponse = await fetch(
-      pluginConfig.luxThemesUrl,
-      { credentials: pluginConfig.credentials || 'same-origin' },
-    ).then((response) => response.json());
+    const cacheVersion = Date.now();
+    const themesUrl = `${pluginConfig.luxThemesUrl}&cache_version=${cacheVersion}`;
+    const themesResponse: ThemesResponse = await fetch(themesUrl, {
+      credentials: pluginConfig.credentials || 'same-origin',
+    }).then((response) => response.json());
     const { themes } = themesResponse;
     const terrainUrl = themesResponse.lux_3d.terrain_url;
     const baselayers = themesResponse.background_layers.map(

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,5 +1,6 @@
 import { VcsModule } from '@vcmap/core';
 import type { VcsPlugin, VcsUiApp, PluginConfigEditor } from '@vcmap/ui';
+import { TrustedServers } from '@vcmap-cesium/engine';
 import { name, version, mapVersion } from '../package.json';
 import {
   LOCALES,
@@ -154,6 +155,11 @@ export default function lux3dviewerThemesyncPlugin(
     await setActiveBaselayer(vcsUiApp, pluginConfig, baselayers);
   }
 
+  function includeCredentialsForUrl(url: string): void {
+    const { hostname, port } = new URL(url);
+    TrustedServers.add(hostname, port ? parseInt(port, 10) : 443);
+  }
+
   return {
     get name(): string {
       return name;
@@ -165,6 +171,8 @@ export default function lux3dviewerThemesyncPlugin(
       return mapVersion;
     },
     async initialize(vcsUiApp: VcsUiApp): Promise<void> {
+      includeCredentialsForUrl(pluginConfig.luxOwsUrl);
+      includeCredentialsForUrl(pluginConfig.luxWmtsUrl);
       await loadThemes(vcsUiApp);
     },
     async reloadThemes(vcsUiApp: VcsUiApp): Promise<void> {

--- a/src/index.ts
+++ b/src/index.ts
@@ -14,7 +14,9 @@ import { setActiveBaselayer, mapThemeToConfig } from './utils';
 
 type PluginState = Record<never, never>;
 
-type Lux3dviewerThemesyncPlugin = VcsPlugin<PluginConfig, PluginState>;
+type Lux3dviewerThemesyncPlugin = VcsPlugin<PluginConfig, PluginState> & {
+  reloadThemes(vcsUiApp: VcsUiApp): Promise<void>;
+};
 
 export default function lux3dviewerThemesyncPlugin(
   pluginConfig: PluginConfig,
@@ -103,6 +105,54 @@ export default function lux3dviewerThemesyncPlugin(
     await vcsUiApp.addModule(newModule);
   }
 
+  async function loadThemes(vcsUiApp: VcsUiApp): Promise<void> {
+    const themesResponse: ThemesResponse = await fetch(
+      pluginConfig.luxThemesUrl,
+      { credentials: 'include' },
+    ).then((response) => response.json());
+    const { themes } = themesResponse;
+    const terrainUrl = themesResponse.lux_3d.terrain_url;
+    const baselayers = themesResponse.background_layers.map(
+      (layer: ThemeItem) => ({
+        ...layer,
+        type: 'BaseLayer' as Ol2dLayerType,
+      }),
+    );
+
+    const themesFiltered = themes
+      .filter(
+        (theme) =>
+          theme.metadata?.ol3d_type ||
+          theme.metadata?.display_in_switcher === true,
+      )
+      .sort((a, b) => {
+        if (a.metadata?.ol3d_type) return -1;
+        if (b.metadata?.ol3d_type) return 1;
+        return 0;
+      });
+    themesFiltered.unshift({
+      id: -1,
+      name: 'basemap',
+      children: baselayers,
+    });
+    const translations = await Promise.all(
+      LOCALES.map((locale) =>
+        fetch(
+          `${pluginConfig.luxI18nUrl}/${locale}.json?_t=${Date.now()}`,
+        ).then((response) => response.json()),
+      ),
+    );
+    const flatTranslations = translations.reduce(
+      (acc, curr) => ({ ...acc, ...curr }),
+      {},
+    );
+
+    if (themesFiltered.length > 0) {
+      await addThemes(vcsUiApp, themesFiltered, terrainUrl, flatTranslations);
+    }
+    await setActiveBaselayer(vcsUiApp, pluginConfig, baselayers);
+  }
+
   return {
     get name(): string {
       return name;
@@ -114,52 +164,11 @@ export default function lux3dviewerThemesyncPlugin(
       return mapVersion;
     },
     async initialize(vcsUiApp: VcsUiApp): Promise<void> {
-      // fetch and filter themes
-      const themesResponse: ThemesResponse = await fetch(
-        pluginConfig.luxThemesUrl,
-      ).then((response) => response.json());
-      const { themes } = themesResponse;
-      const terrainUrl = themesResponse.lux_3d.terrain_url;
-      const baselayers = themesResponse.background_layers.map(
-        (layer: ThemeItem) => ({
-          ...layer,
-          type: 'BaseLayer' as Ol2dLayerType,
-        }),
-      );
-
-      const themesFiltered = themes
-        .filter(
-          (theme) =>
-            theme.metadata?.ol3d_type ||
-            theme.metadata?.display_in_switcher === true,
-        )
-        .sort((a, b) => {
-          if (a.metadata?.ol3d_type) return -1;
-          if (b.metadata?.ol3d_type) return 1;
-          return 0;
-        });
-      themesFiltered.unshift({
-        id: -1,
-        name: 'basemap',
-        children: baselayers,
-      });
-      // fetch and flatten translations
-      const translations = await Promise.all(
-        LOCALES.map((locale) =>
-          fetch(
-            `${pluginConfig.luxI18nUrl}/${locale}.json?_t=${Date.now()}`,
-          ).then((response) => response.json()),
-        ),
-      );
-      const flatTranslations = translations.reduce(
-        (acc, curr) => ({ ...acc, ...curr }),
-        {},
-      );
-
-      if (themesFiltered.length > 0) {
-        await addThemes(vcsUiApp, themesFiltered, terrainUrl, flatTranslations);
-      }
-      await setActiveBaselayer(vcsUiApp, pluginConfig, baselayers);
+      await loadThemes(vcsUiApp);
+    },
+    async reloadThemes(vcsUiApp: VcsUiApp): Promise<void> {
+      await vcsUiApp.removeModule('catalogConfig');
+      await loadThemes(vcsUiApp);
     },
     onVcsAppMounted(): void {},
     /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -108,7 +108,7 @@ export default function lux3dviewerThemesyncPlugin(
   async function loadThemes(vcsUiApp: VcsUiApp): Promise<void> {
     const themesResponse: ThemesResponse = await fetch(
       pluginConfig.luxThemesUrl,
-      { credentials: 'include' },
+      { credentials: pluginConfig.credentials || 'same-origin' },
     ).then((response) => response.json());
     const { themes } = themesResponse;
     const terrainUrl = themesResponse.lux_3d.terrain_url;

--- a/src/model.ts
+++ b/src/model.ts
@@ -11,6 +11,7 @@ export type PluginConfig = {
   luxLegendUrl: string;
   luxDefaultBaselayer: string;
   luxGeonetworkUrl?: string;
+  credentials?: RequestCredentials;
 };
 
 export interface ThemeItem {


### PR DESCRIPTION
Prepares lux-3dviewer-themesync for integration with the new lux-3dviewer-plugin-auth plugin:

  - Adds reloadThemes() method so the auth plugin can refresh the content tree after login/logout
  - Fetches themes with configurable credentials so private/role-based layers are returned for authenticated users
  - Registers luxOwsUrl and luxWmtsUrl as Cesium TrustedServers so layer tile requests include credentials
  - Busts the themes cache on each reload to prevent stale responses
