### PR TITLE
GSLUX-809 Only include credentials for proteced layers

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,10 +12,11 @@ To further develop the plugin run: `npm start`
 
 These params (mostly URLs) must be indicated in the plugin config when deployed:
 
-- `luxThemesUrl`- URL to themes API
+- `luxThemesUrl`- URL to themes API (requests to this URL include credentials accoring to the credentials property in this config)
 - `luxI18nUrl`- URL to translations
-- `luxOwsUrl`- URL to OGC web services
-- `luxWmtsUrl`- URL to WMTS
+- `luxOwsUrl`- URL to OGC web services (thematic WMS and WMTS displayed as WMS to include fetaure info)
+- `luxWmtsUrl`- URL to WMTS (baselayers)
+- `luxProxyUrl` - URL to proxy service for protected layers (requests to this URL always include credentials)
 - `luxLegendUrl` - URL to legends
 - `luxDefaultBaselayer` - name of the default baselayer to display
 - `credentials` - RequestCredentials property for theme fetching: `omit`, `same-origin` (default) or `include` (for dev only)
@@ -41,6 +42,7 @@ These params (mostly URLs) must be indicated in the plugin config when deployed:
       "luxI18nUrl": "...",
       "luxOwsUrl": "...",
       "luxWmtsUrl": "...",
+      "luxProxyUrl": "...",
       "luxLegendUrl": "...",
       "luxDefaultBaselayer": "...",
       "credentials": "...",

--- a/config.json
+++ b/config.json
@@ -4,6 +4,7 @@
   "luxI18nUrl": "https://map.geoportail.lu/static/0",
   "luxOwsUrl": "https://wms.geoportail.lu/public_map_layers/service",
   "luxWmtsUrl": "https://wmts3.geoportail.lu/mapproxy_4_v3/wmts",
+  "luxProxyUrl": "https://wmsproxy.geoportail.lu/ogcproxywms",
   "luxLegendUrl": "https://map.geoportail.lu/legends/get_html",
   "luxDefaultBaselayer": "orthogr_2013_global",
   "luxGeonetworkUrl": "https://geocatalogue.geoportail.lu/geonetwork/srv",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geoportallux/lux-3dviewer-themesync",
-  "version": "1.5.1-alpha",
+  "version": "1.5.1-beta",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geoportallux/lux-3dviewer-themesync",
-      "version": "1.5.1-alpha",
+      "version": "1.5.1-beta",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geoportallux/lux-3dviewer-themesync",
-  "version": "1.5.1-dev",
+  "version": "1.5.1-alpha",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geoportallux/lux-3dviewer-themesync",
-      "version": "1.5.1-dev",
+      "version": "1.5.1-alpha",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geoportallux/lux-3dviewer-themesync",
-  "version": "1.5.0",
+  "version": "1.5.1-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geoportallux/lux-3dviewer-themesync",
-      "version": "1.5.0",
+      "version": "1.5.1-dev",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoportallux/lux-3dviewer-themesync",
-  "version": "1.5.1-alpha",
+  "version": "1.5.1-beta",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoportallux/lux-3dviewer-themesync",
-  "version": "1.5.1-dev",
+  "version": "1.5.1-alpha",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoportallux/lux-3dviewer-themesync",
-  "version": "1.5.0",
+  "version": "1.5.1-dev",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,8 +171,8 @@ export default function lux3dviewerThemesyncPlugin(
       return mapVersion;
     },
     async initialize(vcsUiApp: VcsUiApp): Promise<void> {
-      includeCredentialsForUrl(pluginConfig.luxOwsUrl);
-      includeCredentialsForUrl(pluginConfig.luxWmtsUrl);
+      // include credentials only for layers queried via proxy url
+      includeCredentialsForUrl(pluginConfig.luxProxyUrl);
       await loadThemes(vcsUiApp);
     },
     async reloadThemes(vcsUiApp: VcsUiApp): Promise<void> {

--- a/src/model.ts
+++ b/src/model.ts
@@ -18,7 +18,8 @@ export type PluginConfig = {
 export interface ThemeItem {
   id: number;
   name: string;
-  layers?: string | number;
+  layer?: string;
+  layers?: number;
   source?: string;
   url?: string;
   style?: string | LayerStyle;

--- a/src/model.ts
+++ b/src/model.ts
@@ -18,7 +18,7 @@ export type PluginConfig = {
 export interface ThemeItem {
   id: number;
   name: string;
-  layer?: string;
+  layers?: string | number;
   source?: string;
   url?: string;
   style?: string | LayerStyle;
@@ -85,7 +85,7 @@ export interface LayerConfig {
   name: string;
   source?: string;
   style?: string | LayerStyle;
-  layers?: number;
+  layers?: string | number;
   activeOnStartup: boolean;
   allowPicking?: boolean;
   properties: Record<string, unknown>;

--- a/src/model.ts
+++ b/src/model.ts
@@ -8,6 +8,7 @@ export type PluginConfig = {
   luxI18nUrl: string;
   luxOwsUrl: string;
   luxWmtsUrl: string;
+  luxProxyUrl: string;
   luxLegendUrl: string;
   luxDefaultBaselayer: string;
   luxGeonetworkUrl?: string;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -133,7 +133,9 @@ export function mapThemeToConfig(
         layerConfig = {
           ...layerConfig,
           type: 'WMSLayer',
-          url: pluginConfig.luxOwsUrl,
+          url: themeItem.url
+            ? pluginConfig.luxOwsUrl // used from config so WMTS layers also point to WMS url for getFeatureInfo
+            : pluginConfig.luxProxyUrl, // if no url in themes api, use proxy url (with credentials via TrustedServers)
           tilingSchema: 'mercator',
           featureInfo: {
             responseType: 'text/html',

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,7 +97,7 @@ export function mapThemeToConfig(
       name: themeItem.name,
       source: themeItem.source,
       style: themeItem.style,
-      layers: themeItem.layers,
+      layers: themeItem.url ? themeItem.id : themeItem.layers, // use layers as identifier when passing via proxy (see used url below)
       activeOnStartup: false,
       allowPicking: !!themeItem.metadata?.is_queryable,
       properties: {
@@ -153,7 +153,7 @@ export function mapThemeToConfig(
         layerConfig = {
           ...layerConfig,
           type: 'WMTSLayer',
-          url: `${pluginConfig.luxWmtsUrl}/${themeItem.layers}/${themeItem.matrixSet}/{TileMatrix}/{TileCol}/{TileRow}.${getFormat(themeItem.imageType)}`,
+          url: `${pluginConfig.luxWmtsUrl}/${themeItem.layer}/${themeItem.matrixSet}/{TileMatrix}/{TileCol}/{TileRow}.${getFormat(themeItem.imageType)}`,
           format: themeItem.imageType,
           extent: {
             coordinates: [-180, -85, 180, 85],
@@ -170,7 +170,7 @@ export function mapThemeToConfig(
       case 'data':
         layerConfig = {
           ...layerConfig,
-          url: `${themeItem.url}/${themeItem.layers}/tileset.json`,
+          url: `${themeItem.url}/${themeItem.layer}/tileset.json`,
           type: 'CesiumTilesetLayer',
           style: get3dStyle(themeItem),
           activeOnStartup: themeItem.metadata?.ol3d_defaultlayer || false,
@@ -181,7 +181,7 @@ export function mapThemeToConfig(
       case 'mesh':
         layerConfig = {
           ...layerConfig,
-          url: `${themeItem.url}/${themeItem.layers}/tileset.json`,
+          url: `${themeItem.url}/${themeItem.layer}/tileset.json`,
           type: 'CesiumTilesetLayer',
           // activeOnStartup: do not recover ol3d_defaultlayer value for mesh as exclusive terrain is already activeOnStartup
           offset: [0, 0, themeItem.metadata?.ol3d_options?.heightOffset || 0],

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,7 +97,7 @@ export function mapThemeToConfig(
       name: themeItem.name,
       source: themeItem.source,
       style: themeItem.style,
-      layers: themeItem.id,
+      layers: themeItem.layers,
       activeOnStartup: false,
       allowPicking: !!themeItem.metadata?.is_queryable,
       properties: {
@@ -153,7 +153,7 @@ export function mapThemeToConfig(
         layerConfig = {
           ...layerConfig,
           type: 'WMTSLayer',
-          url: `${pluginConfig.luxWmtsUrl}/${themeItem.layer}/${themeItem.matrixSet}/{TileMatrix}/{TileCol}/{TileRow}.${getFormat(themeItem.imageType)}`,
+          url: `${pluginConfig.luxWmtsUrl}/${themeItem.layers}/${themeItem.matrixSet}/{TileMatrix}/{TileCol}/{TileRow}.${getFormat(themeItem.imageType)}`,
           format: themeItem.imageType,
           extent: {
             coordinates: [-180, -85, 180, 85],
@@ -170,7 +170,7 @@ export function mapThemeToConfig(
       case 'data':
         layerConfig = {
           ...layerConfig,
-          url: `${themeItem.url}/${themeItem.layer}/tileset.json`,
+          url: `${themeItem.url}/${themeItem.layers}/tileset.json`,
           type: 'CesiumTilesetLayer',
           style: get3dStyle(themeItem),
           activeOnStartup: themeItem.metadata?.ol3d_defaultlayer || false,
@@ -181,7 +181,7 @@ export function mapThemeToConfig(
       case 'mesh':
         layerConfig = {
           ...layerConfig,
-          url: `${themeItem.url}/${themeItem.layer}/tileset.json`,
+          url: `${themeItem.url}/${themeItem.layers}/tileset.json`,
           type: 'CesiumTilesetLayer',
           // activeOnStartup: do not recover ol3d_defaultlayer value for mesh as exclusive terrain is already activeOnStartup
           offset: [0, 0, themeItem.metadata?.ol3d_options?.heightOffset || 0],


### PR DESCRIPTION
This PR is a follow up of #25 to make sure to include credentials only for protected layers, which are queried via the newly introduced `luxProxyUrl`.