### PR TITLE
Align LayerConfig.layers type to VCS models

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@geoportallux/lux-3dviewer-themesync",
-  "version": "1.5.1",
+  "version": "1.5.2-dev",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@geoportallux/lux-3dviewer-themesync",
-      "version": "1.5.1",
+      "version": "1.5.2-dev",
       "license": "GPL-3.0",
       "dependencies": {
         "@zip.js/zip.js": "2.7.34"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@geoportallux/lux-3dviewer-themesync",
-  "version": "1.5.1",
+  "version": "1.5.2-dev",
   "description": "",
   "type": "module",
   "main": "dist/index.js",

--- a/src/model.ts
+++ b/src/model.ts
@@ -86,7 +86,7 @@ export interface LayerConfig {
   name: string;
   source?: string;
   style?: string | LayerStyle;
-  layers?: string | number;
+  layers?: string;
   activeOnStartup: boolean;
   allowPicking?: boolean;
   properties: Record<string, unknown>;

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -97,7 +97,7 @@ export function mapThemeToConfig(
       name: themeItem.name,
       source: themeItem.source,
       style: themeItem.style,
-      layers: themeItem.url ? themeItem.id : themeItem.layers, // use layers as identifier when passing via proxy (see used url below)
+      layers: String(themeItem.url ? themeItem.id : themeItem.layers), // use layers as identifier when passing via proxy (see used url below)
       activeOnStartup: false,
       allowPicking: !!themeItem.metadata?.is_queryable,
       properties: {


### PR DESCRIPTION
... amongst others to prevent error's with map-core's `WMSLayer.getLayers()`